### PR TITLE
fix: Send on enter area event before loading players

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,7 @@ import {
 } from "./types";
 
 import { t } from "i18next";
+import { useEffect, useRef } from "react";
 
 export const EMPTY_ID = 2289754288;
 
@@ -325,3 +326,13 @@ export const translateSigilId = (id: number | null): string => {
 };
 
 export const toHash = (num: number): string => num.toString(16);
+
+export const usePrevious = <T>(value: T): T | undefined => {
+  const ref = useRef<T>();
+
+  useEffect(() => {
+    ref.current = value;
+  });
+
+  return ref.current;
+};


### PR DESCRIPTION
Otherwise, we end up sending the on enter area AFTER we've loaded the 1st player, which ends up clearing it out later on.

Also, remove some unnecessary reads, as we can operate directly on `a1`.