### PR TITLE
feat: Add SBA gauge graph

### DIFF
--- a/src-tauri/lang/en/ui.json
+++ b/src-tauri/lang/en/ui.json
@@ -59,6 +59,7 @@
       "delete-selected-logs-confirmation_other": "This will delete {{count}} logs from the database. This action cannot be undone.",
       "quest-name": "Quest",
       "quest-elapsed-time": "IGT",
+      "sba-chart": "Skybound Arts Gauge",
       "quest-status": "Status",
       "overview": "Overview",
       "equipment": "Equipment"

--- a/src-tauri/lang/en/ui.json
+++ b/src-tauri/lang/en/ui.json
@@ -35,6 +35,11 @@
     "player-overmasteries": "Overmasteries",
     "select-enemy": "Select Enemy",
     "select-quest": "Select Quest",
+    "sba": {
+      "OnAttemptSBA": "Attempted SBA",
+      "OnPerformSBA": "Executed SBA",
+      "OnContinueSBAChain": "Continued SBA Chain"
+    },
     "stats": {
       "total-hp": "Total HP",
       "total-attack": "Total Attack",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -312,7 +312,9 @@ struct EncounterStateResponse {
     quest_completed: bool,
     targets: Vec<EnemyType>,
     dps_chart: HashMap<u32, Vec<i32>>,
+    sba_chart: HashMap<u32, Vec<f32>>,
     chart_len: usize,
+    sba_chart_len: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -337,9 +339,11 @@ fn fetch_encounter_state(id: u64, options: ParseOptions) -> Result<EncounterStat
     parser.reparse_with_options(&options.targets);
 
     let duration = parser.derived_state.duration();
+
     let mut player_dps: HashMap<u32, Vec<i32>> = HashMap::new();
 
     const DPS_INTERVAL: i64 = 3 * 1_000;
+    const SBA_INTERVAL: i64 = 1_000;
 
     for player in parser.derived_state.party.values() {
         player_dps.insert(
@@ -372,6 +376,8 @@ fn fetch_encounter_state(id: u64, options: ParseOptions) -> Result<EncounterStat
         }
     }
 
+    let sba_chart = parser.generate_sba_chart(SBA_INTERVAL);
+
     Ok(EncounterStateResponse {
         encounter_state: parser.derived_state,
         players: parser.encounter.player_data,
@@ -379,7 +385,9 @@ fn fetch_encounter_state(id: u64, options: ParseOptions) -> Result<EncounterStat
         quest_timer: parser.encounter.quest_timer,
         quest_completed: parser.encounter.quest_completed,
         dps_chart: player_dps,
+        sba_chart: sba_chart,
         chart_len: (duration / DPS_INTERVAL) as usize + 1,
+        sba_chart_len: (duration / SBA_INTERVAL) as usize + 1,
         targets,
     })
 }

--- a/src/pages/logs/View.tsx
+++ b/src/pages/logs/View.tsx
@@ -412,6 +412,7 @@ export const ViewPage = () => {
       <Tabs defaultValue="overview" variant="outline">
         <Tabs.List>
           <Tabs.Tab value="overview">{t("ui.logs.overview")}</Tabs.Tab>
+          <Tabs.Tab value="sba">{t("ui.logs.sba-chart")}</Tabs.Tab>
           <Tabs.Tab value="equipment" disabled={playerData.length === 0}>
             {t("ui.logs.equipment")}
           </Tabs.Tab>
@@ -455,23 +456,27 @@ export const ViewPage = () => {
                   content: ({ label, payload }) => <ChartTooltip label={label} payload={payload} />,
                 }}
               />
-              <Text size="sm">{t("ui.logs.sba-chart")}</Text>
-              <LineChart
-                h={400}
-                data={sbaData}
-                dataKey="timestamp"
-                withDots={false}
-                withLegend
-                series={sbaLabels}
-                valueFormatter={(value) => {
-                  return `${value}%`;
-                }}
-                tooltipProps={{
-                  content: ({ label, payload }) => <ChartTooltip label={label} payload={payload} />,
-                }}
-              />
             </Stack>
           </Box>
+        </Tabs.Panel>
+        <Tabs.Panel value="sba">
+          <Group mt="20" gap="xs">
+            <Text size="sm">{t("ui.logs.sba-chart")}</Text>
+            <LineChart
+              h={400}
+              data={sbaData}
+              dataKey="timestamp"
+              withDots={false}
+              withLegend
+              series={sbaLabels}
+              valueFormatter={(value) => {
+                return `${value}%`;
+              }}
+              tooltipProps={{
+                content: ({ label, payload }) => <ChartTooltip label={label} payload={payload} />,
+              }}
+            />
+          </Group>
         </Tabs.Panel>
         <Tabs.Panel value="equipment">
           <Group mt="20" gap="xs">

--- a/src/pages/logs/View.tsx
+++ b/src/pages/logs/View.tsx
@@ -152,6 +152,7 @@ export const ViewPage = () => {
     encounter,
     dpsChart,
     sbaChart,
+    sbaEvents,
     chartLen,
     sbaChartLen,
     targets,
@@ -166,6 +167,7 @@ export const ViewPage = () => {
     encounter: state.encounterState,
     dpsChart: state.dpsChart,
     sbaChart: state.sbaChart,
+    sbaEvents: state.sbaEvents,
     chartLen: state.chartLen,
     sbaChartLen: state.sbaChartLen,
     targets: state.targets,
@@ -476,6 +478,41 @@ export const ViewPage = () => {
                 content: ({ label, payload }) => <ChartTooltip label={label} payload={payload} />,
               }}
             />
+            <Table striped layout="fixed">
+              <Table.Tbody>
+                {sbaEvents.map((payload, index) => {
+                  const [timestamp, event] = payload;
+                  const eventType = Object.keys(event)[0];
+
+                  // @ts-expect-error: eventType is dynamic here.
+                  const player = players.find((p) => p.index === event[eventType].actor_index);
+
+                  const partySlotIndex = playerData.findIndex(
+                    // @ts-expect-error: eventType is dynamic here.
+                    (partyMember) => partyMember?.actorIndex === event[eventType].actor_index
+                  );
+
+                  const playerName = translatedPlayerName(
+                    partySlotIndex,
+                    playerData[partySlotIndex],
+                    player as ComputedPlayerState
+                  );
+
+                  return (
+                    <Table.Tr key={index}>
+                      <Table.Td>
+                        <Text size="xs">{millisecondsToElapsedFormat(timestamp)}</Text>
+                      </Table.Td>
+                      <Table.Td>
+                        <Text size="xs">
+                          {playerName} - {t(`ui.sba.${eventType}`)}
+                        </Text>
+                      </Table.Td>
+                    </Table.Tr>
+                  );
+                })}
+              </Table.Tbody>
+            </Table>
           </Group>
         </Tabs.Panel>
         <Tabs.Panel value="equipment">

--- a/src/stores/useEncounterStore.ts
+++ b/src/stores/useEncounterStore.ts
@@ -4,7 +4,9 @@ import { create } from "zustand";
 interface EncounterStore {
   encounterState: EncounterState | null;
   dpsChart: Record<number, number[]>;
+  sbaChart: Record<number, number[]>;
   chartLen: number;
+  sbaChartLen: number;
   targets: EnemyType[];
   selectedTargets: EnemyType[];
   players: PlayerData[];
@@ -18,7 +20,9 @@ interface EncounterStore {
 export interface EncounterStateResponse {
   encounterState: EncounterState;
   dpsChart: Record<number, number[]>;
+  sbaChart: Record<number, number[]>;
   chartLen: number;
+  sbaChartLen: number;
   targets: EnemyType[];
   players: PlayerData[];
   questId: number | null;
@@ -29,7 +33,9 @@ export interface EncounterStateResponse {
 export const useEncounterStore = create<EncounterStore>((set) => ({
   encounterState: null,
   dpsChart: {},
+  sbaChart: {},
   chartLen: 0,
+  sbaChartLen: 0,
   targets: [],
   selectedTargets: [],
   players: [],
@@ -43,7 +49,9 @@ export const useEncounterStore = create<EncounterStore>((set) => ({
     set({
       encounterState: response.encounterState,
       dpsChart: response.dpsChart,
+      sbaChart: response.sbaChart,
       chartLen: response.chartLen,
+      sbaChartLen: response.sbaChartLen,
       targets: response.targets,
       players: filteredPlayers,
       questId: response.questId,

--- a/src/stores/useEncounterStore.ts
+++ b/src/stores/useEncounterStore.ts
@@ -1,10 +1,11 @@
-import { EncounterState, EnemyType, PlayerData } from "@/types";
+import { EncounterState, EnemyType, PlayerData, SBAEvent } from "@/types";
 import { create } from "zustand";
 
 interface EncounterStore {
   encounterState: EncounterState | null;
   dpsChart: Record<number, number[]>;
   sbaChart: Record<number, number[]>;
+  sbaEvents: SBAEvent[];
   chartLen: number;
   sbaChartLen: number;
   targets: EnemyType[];
@@ -21,6 +22,7 @@ export interface EncounterStateResponse {
   encounterState: EncounterState;
   dpsChart: Record<number, number[]>;
   sbaChart: Record<number, number[]>;
+  sbaEvents: SBAEvent[];
   chartLen: number;
   sbaChartLen: number;
   targets: EnemyType[];
@@ -34,6 +36,7 @@ export const useEncounterStore = create<EncounterStore>((set) => ({
   encounterState: null,
   dpsChart: {},
   sbaChart: {},
+  sbaEvents: [],
   chartLen: 0,
   sbaChartLen: 0,
   targets: [],
@@ -50,6 +53,7 @@ export const useEncounterStore = create<EncounterStore>((set) => ({
       encounterState: response.encounterState,
       dpsChart: response.dpsChart,
       sbaChart: response.sbaChart,
+      sbaEvents: response.sbaEvents,
       chartLen: response.chartLen,
       sbaChartLen: response.sbaChartLen,
       targets: response.targets,

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,3 +202,12 @@ export type Log = {
   questElapsedTime: number | null;
   questCompleted: boolean;
 };
+
+export type SBAEvent = [
+  number,
+  (
+    | { OnAttemptSBA: { actor_index: number } }
+    | { OnPerformSBA: { actor_index: number } }
+    | { OnContinueSBAChain: { actor_index: number } }
+  ),
+];


### PR DESCRIPTION
> work-in-progress

![image](https://github.com/false-spring/gbfr-logs/assets/60109619/193722fd-cd1d-4ed8-961d-1b680509dce9)

Would like to show actual event timestamps when SBA is attempted + used, in addition to showing the change in SBA gauge value.

