### PR TITLE
feat: Add ability to customize meter overlay columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "gbfr-logs",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gbfr-logs",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "dependencies": {
         "@fontsource-variable/noto-sans": "^5.0.1",
+        "@hello-pangea/dnd": "^16.6.0",
         "@mantine/charts": "^7.6.1",
         "@mantine/core": "^7.6.1",
         "@mantine/dropzone": "^7.6.1",
@@ -348,9 +349,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
-      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
+      "integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -920,6 +921,24 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans/-/noto-sans-5.0.1.tgz",
       "integrity": "sha512-XlVsb4O0dQPgl8wupiP4z1HT7BMKVHUvzDQvtC061hB5ylJ+ksDqnI8AsK/Xa9SAoYGXz2K3ehuE76HyEz81OQ=="
+    },
+    "node_modules/@hello-pangea/dnd": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-16.6.0.tgz",
+      "integrity": "sha512-vfZ4GydqbtUPXSLfAvKvXQ6xwRzIjUSjVU0Sx+70VOhc2xx6CdmJXJ8YhH70RpbTUGjxctslQTHul9sIOxCfFQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.24.1",
+        "css-box-model": "^1.2.1",
+        "memoize-one": "^6.0.0",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^8.1.3",
+        "redux": "^4.2.1",
+        "use-memo-one": "^1.1.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -1634,6 +1653,15 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1652,14 +1680,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "devOptional": true
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/react": {
       "version": "18.2.55",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.55.tgz",
       "integrity": "sha512-Y2Tz5P4yz23brwm2d7jNon39qoAtMMmalOQv6+fEFt1mT+FcM3D841wDpoUvFXhaYenuROCy3FZYqdTjM7qVyA==",
-      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1670,7 +1696,7 @@
       "version": "18.2.19",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
       "integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -1678,14 +1704,18 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "devOptional": true
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.1.0",
@@ -2389,6 +2419,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/css-line-break": {
@@ -3633,6 +3671,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -4259,6 +4305,11 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4787,6 +4838,11 @@
         }
       ]
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -4876,6 +4932,49 @@
         "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
+    },
+    "node_modules/react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",
@@ -5060,6 +5159,14 @@
       "peer": true,
       "dependencies": {
         "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5504,8 +5611,7 @@
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "peer": true
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -5770,6 +5876,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/use-sidecar": {
@@ -6260,9 +6374,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.23.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
-      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
+      "integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
@@ -6580,6 +6694,20 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans/-/noto-sans-5.0.1.tgz",
       "integrity": "sha512-XlVsb4O0dQPgl8wupiP4z1HT7BMKVHUvzDQvtC061hB5ylJ+ksDqnI8AsK/Xa9SAoYGXz2K3ehuE76HyEz81OQ=="
+    },
+    "@hello-pangea/dnd": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-16.6.0.tgz",
+      "integrity": "sha512-vfZ4GydqbtUPXSLfAvKvXQ6xwRzIjUSjVU0Sx+70VOhc2xx6CdmJXJ8YhH70RpbTUGjxctslQTHul9sIOxCfFQ==",
+      "requires": {
+        "@babel/runtime": "^7.24.1",
+        "css-box-model": "^1.2.1",
+        "memoize-one": "^6.0.0",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^8.1.3",
+        "redux": "^4.2.1",
+        "use-memo-one": "^1.1.3"
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -7041,6 +7169,15 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -7059,14 +7196,12 @@
     "@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "devOptional": true
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "@types/react": {
       "version": "18.2.55",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.55.tgz",
       "integrity": "sha512-Y2Tz5P4yz23brwm2d7jNon39qoAtMMmalOQv6+fEFt1mT+FcM3D841wDpoUvFXhaYenuROCy3FZYqdTjM7qVyA==",
-      "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -7077,7 +7212,7 @@
       "version": "18.2.19",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
       "integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/react": "*"
       }
@@ -7085,14 +7220,18 @@
     "@types/scheduler": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "devOptional": true
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "7.1.0",
@@ -7562,6 +7701,14 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      }
+    },
+    "css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "requires": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "css-line-break": {
@@ -8497,6 +8644,14 @@
         "function-bind": "^1.1.2"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -8944,6 +9099,11 @@
         "yallist": "^3.0.2"
       }
     },
+    "memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -9272,6 +9432,11 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
+    },
     "react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -9325,6 +9490,26 @@
       "integrity": "sha512-maGHWmOvwYzyeRIpL0YC6drWqYaX6iFqjisdJXpZ+HzEtSEJsL6nqw4azTpF5Sm6SAvwUeAr7JY924Ebqq8EdA==",
       "requires": {
         "prop-types": "^15.7.2"
+      }
+    },
+    "react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
       }
     },
     "react-refresh": {
@@ -9437,6 +9622,14 @@
       "peer": true,
       "requires": {
         "decimal.js-light": "^2.4.1"
+      }
+    },
+    "redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "reflect.getprototypeof": {
@@ -9746,8 +9939,7 @@
     "tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "peer": true
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -9913,6 +10105,12 @@
       "requires": {
         "use-isomorphic-layout-effect": "^1.1.1"
       }
+    },
+    "use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "requires": {}
     },
     "use-sidecar": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@fontsource-variable/noto-sans": "^5.0.1",
+    "@hello-pangea/dnd": "^16.6.0",
     "@mantine/charts": "^7.6.1",
     "@mantine/core": "^7.6.1",
     "@mantine/dropzone": "^7.6.1",

--- a/src-tauri/lang/en/ui.json
+++ b/src-tauri/lang/en/ui.json
@@ -42,6 +42,17 @@
       "OnPerformSBA": "Executed SBA",
       "OnContinueSBAChain": "Continued SBA Chain"
     },
+    "meter-columns": {
+      "name": "Name",
+      "dps": "DPS",
+      "dps-description": "Damage Per Second",
+      "damage": "DMG",
+      "damage-description": "Total Damage",
+      "damage-percentage": "%",
+      "damage-percentage-description": "Total Damage in Percentage",
+      "sba": "SBA",
+      "sba-description": "Skybound Arts Gauge"
+    },
     "stats": {
       "level": "Level",
       "total-hp": "Total HP",

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,6 +1,7 @@
+import { useTranslation } from "react-i18next";
 import { useShallow } from "zustand/react/shallow";
 import { useMeterSettingsStore } from "../stores/useMeterSettingsStore";
-import { ComputedPlayerState, EncounterState, PlayerData, SortDirection, SortType } from "../types";
+import { ComputedPlayerState, EncounterState, MeterColumns, PlayerData, SortDirection, SortType } from "../types";
 import { formatInPartyOrder, sortPlayers } from "../utils";
 import { PlayerRow } from "./PlayerRow";
 
@@ -21,10 +22,12 @@ export const Table = ({
   setSortType: (sortType: SortType) => void;
   setSortDirection: (sortDirection: SortDirection) => void;
 }) => {
-  const { streamerMode, show_full_values } = useMeterSettingsStore(
+  const { t } = useTranslation();
+  const { streamerMode, show_full_values, overlay_columns } = useMeterSettingsStore(
     useShallow((state) => ({
       streamerMode: state.streamer_mode,
       show_full_values: state.show_full_values,
+      overlay_columns: state.overlay_columns,
     }))
   );
 
@@ -56,28 +59,21 @@ export const Table = ({
     }
   };
 
+  // If the meter is in live mode, only show the overlay columns that are enabled, otherwise show all columns.
+  const columns = live ? overlay_columns : [MeterColumns.TotalDamage, MeterColumns.DPS, MeterColumns.DamagePercentage];
+
   return (
     <table className={`player-table table w-full ${show_full_values ? "full-values" : ""}`}>
       <thead className="header transparent-bg">
         <tr>
-          <th className="header-name" onClick={() => toggleSort("partyIndex")}>
+          <th className="header-name" onClick={() => toggleSort(MeterColumns.Name)}>
             Name
           </th>
-          {live && (
-            <th className="header-column text-center" onClick={() => toggleSort("SBA")}>
-              SBA
+          {columns.map((column) => (
+            <th key={column} className="header-column text-center" onClick={() => toggleSort(column)}>
+              {t(`ui.meter-columns.${column}`)}
             </th>
-          )}
-          <th className="header-column text-center" onClick={() => toggleSort("damage")}>
-            DMG
-          </th>
-          <th className="header-column text-center" onClick={() => toggleSort("dps")}>
-            DPS
-          </th>
-          <th className="header-column text-center" onClick={() => toggleSort("percentage")}>
-            %
-          </th>
-          <th className="header-column text-center dropdown" style={{ width: "2em" }}></th>
+          ))}
         </tr>
       </thead>
       <tbody>

--- a/src/pages/Logs.tsx
+++ b/src/pages/Logs.tsx
@@ -14,7 +14,7 @@ const Layout = () => {
 
   useEffect(() => {
     const debugListener = listen("debug-event", (event: { payload: unknown }) => {
-      console.log(JSON.stringify(event.payload));
+      console.info(JSON.stringify(event.payload));
     });
 
     return () => {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,21 @@
-import { Box, Checkbox, ColorInput, Fieldset, Select, Slider, Stack, Text, Tooltip } from "@mantine/core";
+import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd";
+import {
+  ActionIcon,
+  Box,
+  Button,
+  Checkbox,
+  ColorInput,
+  Divider,
+  Fieldset,
+  Flex,
+  Menu,
+  Select,
+  Slider,
+  Stack,
+  Text,
+  Tooltip,
+} from "@mantine/core";
+import { DotsSixVertical } from "@phosphor-icons/react";
 import { invoke } from "@tauri-apps/api";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -20,13 +37,18 @@ const SettingsPage = () => {
     setMeterSettings,
     languages,
     handleLanguageChange,
+    overlay_columns,
+    handleReorderOverlayColumns,
+    availableOverlayColumns,
+    addOverlayColumn,
+    removeOverlayColumn,
   } = useSettings();
 
   const toggleDebugMode = () => {
     const enabled = !debugMode;
     setDebugMode(enabled);
     invoke("set_debug_mode", { enabled });
-    console.log("Debug Mode:", enabled ? "Enabled" : "Disabled");
+    console.info("Debug Mode:", enabled ? "Enabled" : "Disabled");
   };
 
   return (
@@ -98,6 +120,58 @@ const SettingsPage = () => {
           <Tooltip label={t("ui.debug-mode-description")}>
             <Checkbox label={t("ui.debug-mode")} checked={debugMode} onChange={toggleDebugMode} />
           </Tooltip>
+          <Divider />
+          <Text size="sm">Customize Overlay Meter Columns</Text>
+          <Menu shadow="md" trigger="hover" openDelay={100} closeDelay={400}>
+            <Menu.Target>
+              <Button>Add column</Button>
+            </Menu.Target>
+            <Menu.Dropdown>
+              {availableOverlayColumns.map((item) => (
+                <Menu.Item key={item} onClick={() => addOverlayColumn(item)}>
+                  {t(`ui.meter-columns.${item}`)} - {t(`ui.meter-columns.${item}-description`)}
+                </Menu.Item>
+              ))}
+            </Menu.Dropdown>
+          </Menu>
+          <DragDropContext onDragEnd={handleReorderOverlayColumns}>
+            <Droppable droppableId="overlay-columns">
+              {(droppableProvided) => (
+                <Stack ref={droppableProvided.innerRef}>
+                  {overlay_columns.map((item, index) => (
+                    <Draggable key={item} draggableId={item} index={index}>
+                      {(draggableProvided) => (
+                        <Box
+                          bg="var(--mantine-color-dark-8)"
+                          display="flex"
+                          p={10}
+                          ref={draggableProvided.innerRef}
+                          {...draggableProvided.draggableProps}
+                          {...draggableProvided.dragHandleProps}
+                        >
+                          <Flex align="center" flex={1}>
+                            <DotsSixVertical size={16} style={{ cursor: "grab", marginRight: "0.5em" }} />
+                            {t(`ui.meter-columns.${item}`)} - {t(`ui.meter-columns.${item}-description`)}
+                          </Flex>
+                          <Flex align="center">
+                            <ActionIcon
+                              aria-label="Remove column"
+                              variant="transparent"
+                              color="gray"
+                              onClick={() => removeOverlayColumn(item)}
+                            >
+                              x
+                            </ActionIcon>
+                          </Flex>
+                        </Box>
+                      )}
+                    </Draggable>
+                  ))}
+                  {droppableProvided.placeholder}
+                </Stack>
+              )}
+            </Droppable>
+          </DragDropContext>
         </Stack>
       </Fieldset>
     </Box>

--- a/src/pages/logs/View.tsx
+++ b/src/pages/logs/View.tsx
@@ -26,7 +26,15 @@ import { Link, useParams } from "react-router-dom";
 import { Table as MeterTable } from "@/components/Table";
 import { EncounterStateResponse, useEncounterStore } from "@/stores/useEncounterStore";
 import { useMeterSettingsStore } from "@/stores/useMeterSettingsStore";
-import type { ComputedPlayerState, EnemyType, Overmastery, PlayerData, SortDirection, SortType } from "@/types";
+import {
+  MeterColumns,
+  type ComputedPlayerState,
+  type EnemyType,
+  type Overmastery,
+  type PlayerData,
+  type SortDirection,
+  type SortType,
+} from "@/types";
 import {
   EMPTY_ID,
   PLAYER_COLORS,
@@ -189,7 +197,7 @@ export const ViewPage = () => {
     setSelectedTargets: state.setSelectedTargets,
     loadFromResponse: state.loadFromResponse,
   }));
-  const [sortType, setSortType] = useState<SortType>("damage");
+  const [sortType, setSortType] = useState<SortType>(MeterColumns.TotalDamage);
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
 
   useEffect(() => {

--- a/src/pages/useMeter.ts
+++ b/src/pages/useMeter.ts
@@ -1,5 +1,13 @@
 import { useMeterSettingsStore } from "@/stores/useMeterSettingsStore";
-import { EncounterState, EncounterUpdateEvent, PartyUpdateEvent, PlayerData, SortDirection, SortType } from "@/types";
+import {
+  EncounterState,
+  EncounterUpdateEvent,
+  MeterColumns,
+  PartyUpdateEvent,
+  PlayerData,
+  SortDirection,
+  SortType,
+} from "@/types";
 import { usePrevious } from "@mantine/hooks";
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useState } from "react";
@@ -26,7 +34,7 @@ export default function useMeter() {
 
   const previousStatus = usePrevious(encounterState.status);
 
-  const [sortType, setSortType] = useState<SortType>("damage");
+  const [sortType, setSortType] = useState<SortType>(MeterColumns.TotalDamage);
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
   const { transparency } = useMeterSettingsStore(
     useShallow((state) => ({

--- a/src/pages/useSettings.ts
+++ b/src/pages/useSettings.ts
@@ -1,6 +1,16 @@
 import { SUPPORTED_LANGUAGES } from "@/i18n";
 import { useMeterSettingsStore } from "@/stores/useMeterSettingsStore";
+import { MeterColumns } from "@/types";
+import { DropResult } from "@hello-pangea/dnd";
 import { useTranslation } from "react-i18next";
+
+const reorder = <TList extends unknown[]>(list: TList, startIndex: number, endIndex: number): TList => {
+  const result = Array.from(list) as TList;
+  const [removed] = result.splice(startIndex, 1);
+  result.splice(endIndex, 0, removed);
+
+  return result;
+};
 
 export default function useSettings() {
   const {
@@ -12,6 +22,7 @@ export default function useSettings() {
     show_display_names,
     streamer_mode,
     show_full_values,
+    overlay_columns,
     setMeterSettings,
   } = useMeterSettingsStore((state) => ({
     color_1: state.color_1,
@@ -23,15 +34,42 @@ export default function useSettings() {
     streamer_mode: state.streamer_mode,
     show_full_values: state.show_full_values,
     setMeterSettings: state.set,
+    overlay_columns: state.overlay_columns,
   }));
 
   const { i18n } = useTranslation();
 
-  const languages = Object.keys(SUPPORTED_LANGUAGES).map((key) => ({ value: key, label: SUPPORTED_LANGUAGES[key] }));
-
   const handleLanguageChange = (language: string | null) => {
     i18n.changeLanguage(language as string);
   };
+
+  const handleReorderOverlayColumns = (result: DropResult) => {
+    if (!result.destination) return;
+    const items = reorder(overlay_columns, result.source.index, result.destination.index);
+    setMeterSettings({ overlay_columns: items });
+  };
+
+  // Adds a column to the overlay_columns array if it doesn't exist.
+  const addOverlayColumn = (column: MeterColumns) => {
+    const items = [...overlay_columns];
+
+    if (items.indexOf(column) === -1) {
+      items.push(column);
+      setMeterSettings({ overlay_columns: items });
+    }
+  };
+
+  // Removes a column from the overlay_columns array.
+  const removeOverlayColumn = (column: MeterColumns) => {
+    const items = overlay_columns.filter((item) => item !== column);
+    setMeterSettings({ overlay_columns: items });
+  };
+
+  const languages = Object.keys(SUPPORTED_LANGUAGES).map((key) => ({ value: key, label: SUPPORTED_LANGUAGES[key] }));
+
+  const availableOverlayColumns = Object.values(MeterColumns).filter(
+    (column) => overlay_columns.indexOf(column) === -1 && column !== MeterColumns.Name
+  );
 
   return {
     color_1,
@@ -44,6 +82,11 @@ export default function useSettings() {
     show_full_values,
     setMeterSettings,
     languages,
+    overlay_columns,
+    availableOverlayColumns,
     handleLanguageChange,
+    handleReorderOverlayColumns,
+    addOverlayColumn,
+    removeOverlayColumn,
   };
 }

--- a/src/stores/useMeterSettingsStore.ts
+++ b/src/stores/useMeterSettingsStore.ts
@@ -1,3 +1,4 @@
+import { MeterColumns } from "@/types";
 import { Mutate, StoreApi, create } from "zustand";
 import { persist } from "zustand/middleware";
 
@@ -10,6 +11,7 @@ interface MeterSettings {
   show_display_names: boolean;
   streamer_mode: boolean;
   show_full_values: boolean;
+  overlay_columns: MeterColumns[];
 }
 
 interface MeterStateFunctions {
@@ -25,6 +27,7 @@ const DEFAULT_METER_SETTINGS: MeterSettings = {
   show_display_names: true,
   streamer_mode: false,
   show_full_values: false,
+  overlay_columns: [MeterColumns.TotalDamage, MeterColumns.DPS, MeterColumns.DamagePercentage],
 };
 
 export type StoreWithPersist<T> = Mutate<StoreApi<T>, [["zustand/persist", T]]>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,8 +181,17 @@ export type PartyUpdateEvent = {
   payload: Array<PlayerData | null>;
 };
 
-export type SortType = "partyIndex" | "dps" | "damage" | "percentage" | "SBA";
+export enum MeterColumns {
+  Name = "name",
+  DPS = "dps",
+  TotalDamage = "damage",
+  DamagePercentage = "damage-percentage",
+  SBA = "sba",
+}
+
+export type SortType = MeterColumns;
 export type SortDirection = "asc" | "desc";
+
 export type Log = {
   id: number;
   name: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import {
   ComputedSkillState,
   EncounterState,
   EnemyType,
+  MeterColumns,
   PlayerData,
   PlayerState,
   SortDirection,
@@ -143,15 +144,15 @@ export const translatedPlayerName = (
 
 export const sortPlayers = (players: ComputedPlayerState[], sortType: SortType, sortDirection: SortDirection) => {
   players.sort((a, b) => {
-    if (sortType === "partyIndex") {
+    if (sortType === MeterColumns.Name) {
       return sortDirection === "asc" ? a.partyIndex - b.partyIndex : b.partyIndex - a.partyIndex;
-    } else if (sortType === "dps") {
+    } else if (sortType === MeterColumns.DPS) {
       return sortDirection === "asc" ? a.dps - b.dps : b.dps - a.dps;
-    } else if (sortType === "damage") {
+    } else if (sortType === MeterColumns.TotalDamage) {
       return sortDirection === "asc" ? a.totalDamage - b.totalDamage : b.totalDamage - a.totalDamage;
-    } else if (sortType === "percentage") {
+    } else if (sortType === MeterColumns.DamagePercentage) {
       return sortDirection === "asc" ? a?.percentage - b?.percentage : b?.percentage - a?.percentage;
-    } else if (sortType === "SBA") {
+    } else if (sortType === MeterColumns.SBA) {
       return sortDirection === "asc" ? a?.sba - b?.sba : b?.sba - a?.sba;
     }
 


### PR DESCRIPTION
![image](https://github.com/false-spring/gbfr-logs/assets/60109619/6acb70fe-c197-4914-8414-3c627fc14520)

![image](https://github.com/false-spring/gbfr-logs/assets/60109619/c2d24fc7-1929-4a9a-892a-70242871059b)

Be able to re-order columns, add/remove columns, and generally make things scalable as we add more customization options in the future.

Implements https://github.com/false-spring/gbfr-logs/issues/98