### PR TITLE
Add special handling for Ferry

### DIFF
--- a/src-tauri/src/parser/constants.rs
+++ b/src-tauri/src/parser/constants.rs
@@ -104,3 +104,15 @@ impl EnemyType {
         EnemyType::Unknown(hash)
     }
 }
+
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum FerrySkillId {
+    PetNormal = 65u32,
+    BlausGespenst = 1100u32,
+    SicEmGeeGee = 1210u32,
+    Pendel = 1400u32,
+    Strafe = 1500u32,
+    Umlauf = 1700u32,
+}
+

--- a/src-tauri/src/parser/constants.rs
+++ b/src-tauri/src/parser/constants.rs
@@ -110,9 +110,7 @@ impl EnemyType {
 pub enum FerrySkillId {
     PetNormal = 65u32,
     BlausGespenst = 1100u32,
-    SicEmGeeGee = 1210u32,
     Pendel = 1400u32,
     Strafe = 1500u32,
-    Umlauf = 1700u32,
 }
 

--- a/src-tauri/src/parser/v1/mod.rs
+++ b/src-tauri/src/parser/v1/mod.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use tauri::Window;
 
 use super::{
-    constants::{CharacterType, EnemyType},
+    constants::{CharacterType, EnemyType, FerrySkillId},
     v0,
 };
 
@@ -237,6 +237,7 @@ pub struct PlayerState {
     pub index: u32,
     character_type: CharacterType,
     total_damage: u64,
+    last_known_pet_skill: Option<ActionType>,  // used for Ferry's skills that don't keep track of where they came from
     dps: f64,
     skill_breakdown: Vec<SkillState>,
     sba: f64,
@@ -251,16 +252,58 @@ impl PlayerState {
         self.dps = self.total_damage as f64 / ((now - start_time) as f64 / 1000.0);
     }
 
+    // @todo(false): maybe Ferry specific stuff can be removed/abstracted if some extra flags are found or the attribution is fixed
+    fn get_action_from_ferry_damage_event(&mut self, event: &DamageEvent) -> ActionType {
+        // Ferry needs special handling because the action_id that comes back for pet skills is usually wrong
+        // e.g. if you strafe then dodge the action_id for further hits comes back as "dodge"
+        let parent_character_type = CharacterType::from_hash(event.source.parent_actor_type);
+        let child_character_type = CharacterType::from_hash(event.source.actor_type);
+
+        let is_ferry_pet = parent_character_type != child_character_type;
+        let is_ferry_pet_skill = is_ferry_pet && (event.flags & (1 << 2) != 0);  // pet skills for ferry always have this flag set
+        let is_ferry_pet_normal = is_ferry_pet && !is_ferry_pet_skill && event.action_id != ActionType::LinkAttack;
+        if is_ferry_pet_skill && vec![
+            FerrySkillId::BlausGespenst,
+            FerrySkillId::SicEmGeeGee,
+            FerrySkillId::Pendel,
+            FerrySkillId::Strafe,
+        ].into_iter().any(|skill_id| ActionType::Normal(skill_id as u32) == event.action_id) {
+            self.last_known_pet_skill = Some(event.action_id);
+        }
+        const UMLAUF: ActionType = ActionType::Normal(FerrySkillId::Umlauf as u32);
+        const PET_NORMAL: ActionType = ActionType::Normal(FerrySkillId::PetNormal as u32);
+        let action = if is_ferry_pet_normal {
+            // Note technically the pet portion of Onslaught will count as a Pet normal, but I think that's fine since
+            // it does exactly as much as a pet normal. Could consider adding Onslaught (pet) as a separate category
+            PET_NORMAL
+        } else if is_ferry_pet_skill && event.action_id == UMLAUF {  // Umlauf is the one skill that has working damage attribution
+            UMLAUF
+        } else if is_ferry_pet_skill {
+            // An attempt to fix misattribution for pet skills that work in the background
+            // it can still misattribute one pet skill for another depending on how you cancel your skills
+            // but it should no longer attribute a pet skill to dodging or your Launch attack
+            // only complete fix I see would be to classify skill damage by pet name rather than skill name (e.g. Beppo - Skill vs. Strafe)
+            match self.last_known_pet_skill {
+                None => PET_NORMAL,  // May be good to have a separate "pet skill" backup
+                Some(skill_id) => skill_id,
+            }
+        } else {
+            event.action_id
+        };
+        return action;
+    }
+
     fn update_from_damage_event(&mut self, event: &DamageEvent) {
         self.total_damage += event.damage as u64;
 
         let parent_character_type = CharacterType::from_hash(event.source.parent_actor_type);
+        let child_character_type = CharacterType::from_hash(event.source.actor_type);
 
-        // @TODO(false): This is temporarily fixing Ferry's pets overwriting Ferry's actions.
-        let child_character_type = if parent_character_type == CharacterType::Pl0700 {
-            parent_character_type
+        // for ferry defer to special function to handle the weird way her pets work
+        let action = if parent_character_type == CharacterType::Pl0700 {
+            self.get_action_from_ferry_damage_event(event)
         } else {
-            CharacterType::from_hash(event.source.actor_type)
+            event.action_id
         };
 
         // If the skill is already being tracked, update it.
@@ -270,7 +313,7 @@ impl PlayerState {
                 skill.action_type,
                 protocol::ActionType::SupplementaryDamage(_)
             ) && matches!(
-                event.action_id,
+                action,
                 protocol::ActionType::SupplementaryDamage(_)
             ) {
                 skill.update_from_damage_event(event);
@@ -278,7 +321,7 @@ impl PlayerState {
             }
 
             // If the skill is already being tracked, update it.
-            if skill.action_type == event.action_id
+            if skill.action_type == action
                 && skill.child_character_type == child_character_type
             {
                 skill.update_from_damage_event(event);
@@ -287,7 +330,7 @@ impl PlayerState {
         }
 
         // Otherwise, create a new skill and track it.
-        let mut skill = SkillState::new(event.action_id, child_character_type);
+        let mut skill = SkillState::new(action, child_character_type);
 
         skill.update_from_damage_event(event);
         self.skill_breakdown.push(skill);
@@ -454,6 +497,7 @@ impl DerivedEncounterState {
                 dps: 0.0,
                 sba: 0.0,
                 skill_breakdown: Vec::new(),
+                last_known_pet_skill: None,
             });
 
         // Update player stats from damage event.

--- a/src-tauri/src/parser/v1/mod.rs
+++ b/src-tauri/src/parser/v1/mod.rs
@@ -274,12 +274,8 @@ impl PlayerState {
             // it does exactly as much as a pet normal. Could consider adding Onslaught (pet) as a separate category
             PET_NORMAL
         } else if is_ferry_pet_skill {
-            // An attempt to fix misattribution for pet skills that work in the background
-            // it can still misattribute one pet skill for another depending on how you cancel your skills
-            // but it should no longer attribute a pet skill to dodging or your Launch attack
-            // only complete fix I see would be to classify skill damage by pet name rather than skill name (e.g. Beppo - Skill vs. Strafe)
             match self.last_known_pet_skill {
-                None => PET_NORMAL,  // May be good to have a separate "pet skill" backup
+                None => PET_NORMAL,  // May be good to instead have a separate "pet skill" backup for this case
                 Some(skill_id) => skill_id,
             }
         } else {


### PR DESCRIPTION
Hello! Disclaimer: this is the first time I've written Rust code so I apologize in advance if I'm breaking conventions or it's sloppy for the language. Feel free to make any changes or take and leave what you deem appropriate, just laying some groundwork here.

This is a set of changes to fix damage attribution for Ferry's pets. Pretty much there is currently an issue where pet damage gets attributed to the wrong skills. This is because the action_id coming back for these skills gets updated to the last ability used. For example if you use the Strafe skill then dodge, the damage events that come after the dodge have the skill id for Dodge rather than strafe. While this is an issue with where the numbers are coming from I wasn't sure if it was even possible to fix given that information on the events comes from the game itself I believe?

Fortunately the actor ids let us know when the damage is coming from a pet. There is also a flag that seems to indicate the damage is coming from a pet skill rather than a pet auto attack, so that lets us attribute normal pet damage via seeing if that flag is off.

However for Skills the problem is not entirely fixable. The way I have this fix set up, it will attribute skill damage to the last pet skill seen. So if you start a strafe then dodge it will continue counting towards strafe until it sees a new pet skill. One issue here is if you dodge before any strafes hit the very first action_id is for dodge and there is never an action_id for Strafe... as far as I can tell there is no true way to tell what the ability was. In such cases we just drop damage into the standard "pets" bucket. It's also possible to misattribute one pet skill for another via a similar manner. While unfortunate it's at least better than it currently is. One longer term fix may be to just assign pet skill damage to it's own bucket. e.g. "Nicola - Skill". So even if the skill name is not there you can kind of guess that Nicola - Skill damage is from whatever skills were summoning him. It's not as descriptive but should be 100% accurate at least. The current approach is not 100% accurate if you cancel a lot but for most people probably makes more sense. Also pet skill damage will only incorrectly go into other pet skills, at the very least it should no longer leak into every ability you use.


Also sidenote: The pet damage portion of Onslaught will now go into the "Pets" bucket how I have it. It's easy to put it back in Onslaught if we want but since the damage cap is the same as the pet auto damage cap I think it actually makes more sense under Pets. It also doesn't benefit from supplementary damage like the rest of Onslaught so it's good to have it separate for mathing out how valuable supp damage would be for you. Ideally I think there would be another "Onslaught - Pet" bucket we could toss it in but I didn't want to make new buckets since then I would need to translate etc.


**Screenshots**

Pre-fix:
![ferryPreFixDps](https://github.com/false-spring/gbfr-logs/assets/17091927/adc9c1a9-3db6-48b9-b948-a01599bba6e5)

You can see "Dodge (?)" has eaten up a lot of the Strafe damage. You can also see the pet attacks have no category and are eating into the other ones like Attack 1 (min damage is 18.4k which is the pet attack).

Post-fix:
![ferryPostFixDps](https://github.com/false-spring/gbfr-logs/assets/17091927/f518227e-3673-42fa-aa88-32ea0291f994)

I did roughly the same set of actions for this one but you can see that the "Dodge (?)" is now gone and all the damage is attributed to Strafe. You can also see the Pet autos after now are properly in the "Pets" section and are not attributed to the Attack 1 at all (min values are as we expect)

