### PR TITLE
[feature] Add an Option to Condense Skills into Smaller Categories

### DIFF
--- a/src-tauri/lang/en/ui.json
+++ b/src-tauri/lang/en/ui.json
@@ -31,6 +31,8 @@
     "streamer-mode-description": "Only shows your damage in the meter.",
     "show-full-values": "Show Full Values",
     "show-full-values-description": "Show full values in the meter.",
+    "use-condensed-skills": "Use Condensed Skill Names",
+    "use-condensed-skills-description": "Groups various skills into one entry (e.g. Attack 1, Attack 2 would condense into just \"Attack\")",
     "debug-mode": "Debug Mode",
     "debug-mode-description": "Opens the developer console to view all raw event data.",
     "weapon": "Weapon",

--- a/src/components/PlayerRow.tsx
+++ b/src/components/PlayerRow.tsx
@@ -1,5 +1,5 @@
 import { useMeterSettingsStore } from "@/stores/useMeterSettingsStore";
-import { CharacterType, ComputedPlayerState, ComputedSkillState, MeterColumns, PlayerData } from "@/types";
+import { CharacterType, ComputedPlayerState, ComputedSkillState, MeterColumns, PlayerData, SkillState } from "@/types";
 import { getSkillName, humanizeNumbers, translatedPlayerName } from "@/utils";
 import { CaretDown, CaretUp } from "@phosphor-icons/react";
 import { Fragment, useState } from "react";
@@ -11,7 +11,6 @@ type Props = {
 };
 
 const SkillRow = ({
-  characterType,
   skill,
   color,
 }: {
@@ -33,7 +32,7 @@ const SkillRow = ({
 
   return (
     <tr className="skill-row">
-      <td className="text-left row-data">{getSkillName(characterType, skill)}</td>
+      <td className="text-left row-data">{skill.groupName}</td>
       <td className="text-center row-data">{skill.hits}</td>
       <td className="text-center row-data">
         {show_full_values ? (
@@ -92,16 +91,48 @@ const SkillRow = ({
   );
 };
 
-const SkillBreakdown = ({ player, color }: Props) => {
+const SkillBreakdown = ({ player, color}: Props) => {
+  const {useCondensedSkills} = useMeterSettingsStore(
+    useShallow((state) => ({
+      useCondensedSkills: state.use_condensed_skills,
+    }))
+  );
+
   const totalDamage = player.skillBreakdown.reduce((acc, skill) => acc + skill.totalDamage, 0);
   const computedSkills = player.skillBreakdown.map((skill) => {
     return {
       percentage: (skill.totalDamage / totalDamage) * 100,
+      groupName: getSkillName(player.characterType, skill),
       ...skill,
     };
   });
 
-  computedSkills.sort((a, b) => b.totalDamage - a.totalDamage);
+  let skillsToShow = computedSkills;
+
+  if (useCondensedSkills) {
+    const mergedSkillMap:Map<string, ComputedSkillState> = new Map();
+    const matchRegex = /^([^(0-9]+).*/  // Will match "Attack 1" and "Attack 2" to just "Attack ". Assumes skill names won't have numbers in them otherwise
+    const groupingFn = (skillName: string) => (skillName.match(matchRegex)?.[1] ?? skillName).trim();
+    computedSkills.forEach((skill) => {
+      const shortName = groupingFn(skill.groupName);
+      const existing: ComputedSkillState | undefined= mergedSkillMap.get(shortName);
+      mergedSkillMap.set(shortName, {
+        groupName: shortName,
+        minDamage: Math.min(existing?.totalDamage ?? Number.MAX_VALUE, skill.minDamage ?? Number.MAX_VALUE),
+        maxDamage: Math.max(existing?.totalDamage ?? Number.MIN_VALUE, skill.maxDamage ?? Number.MIN_VALUE),
+        hits: (existing?.hits ?? 0) + skill.hits,
+        totalDamage: (existing?.totalDamage ?? 0) + skill.totalDamage,
+        percentage: (existing?.percentage ?? 0) + skill.percentage,
+        
+        // Just take the first childCharacterType and actionType since there is no good way to merge them
+        childCharacterType: existing?.childCharacterType ?? skill.childCharacterType,
+        actionType: existing?.actionType ?? skill.actionType,
+      })
+    })
+    skillsToShow = [...mergedSkillMap.values()];
+  }
+
+  skillsToShow.sort((a, b) => b.totalDamage - a.totalDamage);
 
   return (
     <tr className="skill-table">
@@ -119,9 +150,9 @@ const SkillBreakdown = ({ player, color }: Props) => {
             </tr>
           </thead>
           <tbody className="transparent-bg">
-            {computedSkills.map((skill) => (
+            {skillsToShow.map((skill) => (
               <SkillRow
-                key={`${skill.childCharacterType}-${getSkillName(player.characterType, skill)}`}
+                key={`${skill.childCharacterType}-${skill.groupName}`}
                 characterType={player.characterType}
                 skill={skill}
                 color={color}

--- a/src/components/PlayerRow.tsx
+++ b/src/components/PlayerRow.tsx
@@ -111,7 +111,7 @@ const SkillBreakdown = ({ player, color}: Props) => {
 
   if (useCondensedSkills) {
     const mergedSkillMap:Map<string, ComputedSkillState> = new Map();
-    const matchRegex = /^([^(0-9]+).*/  // Will match "Attack 1" and "Attack 2" to just "Attack ". Assumes skill names won't have numbers in them otherwise
+    const matchRegex = /(.+?)(Lvl [0-9]+|[0-9]|\().*/  // Will match "Attack 1" and "Attack 2" to just "Attack ". Assumes skill names won't have numbers in them otherwise
     const groupingFn = (skillName: string) => (skillName.match(matchRegex)?.[1] ?? skillName).trim();
     computedSkills.forEach((skill) => {
       const shortName = groupingFn(skill.groupName);

--- a/src/components/PlayerRow.tsx
+++ b/src/components/PlayerRow.tsx
@@ -10,14 +10,7 @@ type Props = {
   color: string;
 };
 
-const SkillRow = ({
-  skill,
-  color,
-}: {
-  characterType: CharacterType;
-  skill: ComputedSkillState;
-  color: string;
-}) => {
+const SkillRow = ({ skill, color }: { characterType: CharacterType; skill: ComputedSkillState; color: string }) => {
   const { show_full_values } = useMeterSettingsStore(
     useShallow((state) => ({
       show_full_values: state.show_full_values,
@@ -91,8 +84,8 @@ const SkillRow = ({
   );
 };
 
-const SkillBreakdown = ({ player, color}: Props) => {
-  const {useCondensedSkills} = useMeterSettingsStore(
+const SkillBreakdown = ({ player, color }: Props) => {
+  const { useCondensedSkills } = useMeterSettingsStore(
     useShallow((state) => ({
       useCondensedSkills: state.use_condensed_skills,
     }))
@@ -110,12 +103,12 @@ const SkillBreakdown = ({ player, color}: Props) => {
   let skillsToShow = computedSkills;
 
   if (useCondensedSkills) {
-    const mergedSkillMap:Map<string, ComputedSkillState> = new Map();
-    const matchRegex = /(.+?)(Lvl [0-9]+|[0-9]|\().*/  // Will match "Attack 1" and "Attack 2" to just "Attack ". Assumes skill names won't have numbers in them otherwise
+    const mergedSkillMap: Map<string, ComputedSkillState> = new Map();
+    const matchRegex = /(.+?)(Lvl [0-9]+|[0-9]|\().*/; // Will match "Attack 1" and "Attack 2" to just "Attack ". Assumes skill names won't have numbers in them otherwise
     const groupingFn = (skillName: string) => (skillName.match(matchRegex)?.[1] ?? skillName).trim();
     computedSkills.forEach((skill) => {
       const shortName = groupingFn(skill.groupName);
-      const existing: ComputedSkillState | undefined= mergedSkillMap.get(shortName);
+      const existing: ComputedSkillState | undefined = mergedSkillMap.get(shortName);
       mergedSkillMap.set(shortName, {
         groupName: shortName,
         minDamage: Math.min(existing?.totalDamage ?? Number.MAX_VALUE, skill.minDamage ?? Number.MAX_VALUE),
@@ -123,12 +116,12 @@ const SkillBreakdown = ({ player, color}: Props) => {
         hits: (existing?.hits ?? 0) + skill.hits,
         totalDamage: (existing?.totalDamage ?? 0) + skill.totalDamage,
         percentage: (existing?.percentage ?? 0) + skill.percentage,
-        
+
         // Just take the first childCharacterType and actionType since there is no good way to merge them
         childCharacterType: existing?.childCharacterType ?? skill.childCharacterType,
         actionType: existing?.actionType ?? skill.actionType,
-      })
-    })
+      });
+    });
     skillsToShow = [...mergedSkillMap.values()];
   }
 

--- a/src/components/PlayerRow.tsx
+++ b/src/components/PlayerRow.tsx
@@ -1,5 +1,5 @@
 import { useMeterSettingsStore } from "@/stores/useMeterSettingsStore";
-import { CharacterType, ComputedPlayerState, ComputedSkillState, MeterColumns, PlayerData, SkillState } from "@/types";
+import { CharacterType, ComputedPlayerState, ComputedSkillState, MeterColumns, PlayerData } from "@/types";
 import { getSkillName, humanizeNumbers, translatedPlayerName } from "@/utils";
 import { CaretDown, CaretUp } from "@phosphor-icons/react";
 import { Fragment, useState } from "react";

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -25,6 +25,7 @@ export const Table = ({
   const { t } = useTranslation();
   const { streamerMode, show_full_values, overlay_columns } = useMeterSettingsStore(
     useShallow((state) => ({
+      useCondensedSkills: state.use_condensed_skills,
       streamerMode: state.streamer_mode,
       show_full_values: state.show_full_values,
       overlay_columns: state.overlay_columns,

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -34,6 +34,7 @@ const SettingsPage = () => {
     show_display_names,
     streamer_mode,
     show_full_values,
+    use_condensed_skills,
     setMeterSettings,
     languages,
     handleLanguageChange,
@@ -115,6 +116,13 @@ const SettingsPage = () => {
               label={t("ui.show-full-values")}
               checked={show_full_values}
               onChange={(event) => setMeterSettings({ show_full_values: event.currentTarget.checked })}
+            />
+          </Tooltip>
+          <Tooltip label={t("ui.use-condensed-skills-description")}>
+            <Checkbox
+              label={t("ui.use-condensed-skills")}
+              checked={use_condensed_skills}
+              onChange={(event) => setMeterSettings({ use_condensed_skills: event.currentTarget.checked })}
             />
           </Tooltip>
           <Tooltip label={t("ui.debug-mode-description")}>

--- a/src/pages/useSettings.ts
+++ b/src/pages/useSettings.ts
@@ -22,6 +22,7 @@ export default function useSettings() {
     show_display_names,
     streamer_mode,
     show_full_values,
+    use_condensed_skills,
     overlay_columns,
     setMeterSettings,
   } = useMeterSettingsStore((state) => ({
@@ -33,6 +34,7 @@ export default function useSettings() {
     show_display_names: state.show_display_names,
     streamer_mode: state.streamer_mode,
     show_full_values: state.show_full_values,
+    use_condensed_skills: state.use_condensed_skills,
     setMeterSettings: state.set,
     overlay_columns: state.overlay_columns,
   }));
@@ -80,6 +82,7 @@ export default function useSettings() {
     show_display_names,
     streamer_mode,
     show_full_values,
+    use_condensed_skills,
     setMeterSettings,
     languages,
     overlay_columns,

--- a/src/stores/useMeterSettingsStore.ts
+++ b/src/stores/useMeterSettingsStore.ts
@@ -11,6 +11,7 @@ interface MeterSettings {
   show_display_names: boolean;
   streamer_mode: boolean;
   show_full_values: boolean;
+  use_condensed_skills: boolean;
   overlay_columns: MeterColumns[];
 }
 
@@ -27,6 +28,7 @@ const DEFAULT_METER_SETTINGS: MeterSettings = {
   show_display_names: true,
   streamer_mode: false,
   show_full_values: false,
+  use_condensed_skills: false,
   overlay_columns: [MeterColumns.TotalDamage, MeterColumns.DPS, MeterColumns.DamagePercentage],
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,8 @@ export type SkillState = {
 export type ComputedSkillState = SkillState & {
   /** Damage contribution as a percentage of the total */
   percentage: number;
+  /** name for grouped skills (e.g. Charged Shot 1 might be under the Charged Shot group) */
+  groupName: string;
 };
 
 export type PlayerState = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,12 +5,12 @@ import toast from "react-hot-toast";
 import {
   CharacterType,
   ComputedPlayerState,
-  ComputedSkillState,
   EncounterState,
   EnemyType,
   MeterColumns,
   PlayerData,
   PlayerState,
+  SkillState,
   SortDirection,
   SortType,
 } from "./types";
@@ -46,7 +46,7 @@ export const epochToLocalTime = (epoch: number): string => {
   }).format(utc);
 };
 
-export const getSkillName = (characterType: CharacterType, skill: ComputedSkillState) => {
+export const getSkillName = (characterType: CharacterType, skill: SkillState) => {
   switch (true) {
     case skill.actionType === "LinkAttack":
       return t([`skills.${characterType}.link-attack`, "skills.default.link-attack"]);


### PR DESCRIPTION
For some characters it is hard to tell exactly what percentage of your damage is what because of how many spell ids there can be. It's even worse with this patch since they split some skills out based off hard long you've charged them etc. to give them different damage caps. This is just a quick and dirty way to merge them all if you want to make it more readable

Added it to where the other options are to be consistent but I could see this being more useful as a toggle in the meter itself
![image](https://github.com/false-spring/gbfr-logs/assets/17091927/00f292f4-5a62-4826-86ca-0dd7ea7ae21f)


Uncondensed (Before):
![image](https://github.com/false-spring/gbfr-logs/assets/17091927/ed0a14fe-f133-43e7-8b08-156fa062e626)

Condensed (After):
![image](https://github.com/false-spring/gbfr-logs/assets/17091927/b9021f9e-3bf2-4638-ab03-118edb6fbdb5)


Related to https://github.com/false-spring/gbfr-logs/issues/68 - not quite as nice but works as a starting point maybe.

As a further improvement could change it from a simple toggle to a grouping strategy selector. For example you might want all skills to become "Skill" all normal attacks become "Attack" just to see what percentage of your damage is Skills etc. without having to add them all up.
