### PR TITLE
feat: Add capability for Rose Palace to be tracked + fix messages being dropped in-transit 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,6 +1435,8 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-window-state",
  "tokio",
+ "tokio-stream",
+ "tokio-util",
  "zstd",
 ]
 
@@ -1842,6 +1844,7 @@ dependencies = [
  "retour",
  "thiserror",
  "tokio",
+ "tokio-util",
  "windows 0.52.0",
  "winres",
 ]
@@ -2076,30 +2079,17 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "1.2.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f2533f3be42fffe3b5e63b71aeca416c1c3bc33e4e27be018521e76b1f38fb"
+checksum = "7c7fb8583fab9503654385e2bafda123376445a77027a1b106dd7e44cf51122f"
 dependencies = [
- "blocking",
- "cfg-if",
  "futures-core",
- "futures-io",
- "intmap",
  "libc",
- "once_cell",
- "rustc_version",
- "spinning",
- "thiserror",
- "to_method",
+ "recvmsg",
  "tokio",
- "winapi",
+ "widestring",
+ "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "intmap"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae52f28f45ac2bc96edb7714de995cffc174a395fb0abf5bff453587c980d7b9"
 
 [[package]]
 name = "io-lifetimes"
@@ -3364,6 +3354,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4078,15 +4074,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spinning"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4695,12 +4682,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "to_method"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
-
-[[package]]
 name = "tokio"
 version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4741,17 +4722,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.10"
+name = "tokio-stream"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/src-hook/Cargo.toml
+++ b/src-hook/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0"
 ctor = "0.2.6"
 dirs = "5.0"
 fern = { version = "0.6" }
-interprocess = { version = "1.2.1", features = ["tokio_support"] }
+interprocess = { version = "^2.0", features = ["tokio"] }
 log = "0.4"
 pelite = "0.10.0"
 retour = { version = "0.3.1", features = ["static-detour"] }
@@ -28,6 +28,7 @@ tokio = { version = "1.0", features = ["full"] }
 windows = { version = "0.52.0", features = ["Win32_Foundation", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Console"] }
 futures = "0.3"
 protocol = { path = "../protocol" }
+tokio-util = { version = "0.7.11", features = ["codec"] }
 
 
 [build-dependencies]

--- a/src-hook/src/hooks/mod.rs
+++ b/src-hook/src/hooks/mod.rs
@@ -72,6 +72,7 @@ pub fn actor_idx(actor_ptr: *const usize) -> u32 {
 }
 
 // Returns the parent entity of the source entity if necessary.
+#[inline(always)]
 pub fn get_source_parent(source_type_id: u32, source: *const usize) -> Option<(u32, u32)> {
     match source_type_id {
         // Pl0700Ghost -> Pl0700
@@ -113,6 +114,7 @@ pub fn get_source_parent(source_type_id: u32, source: *const usize) -> Option<(u
 // Returns the specified instance of the parent entity.
 // ptr+offset: Entity
 // *(ptr+offset) + 0x70: m_pSpecifiedInstance (Pl0700, Pl1200, etc.)
+#[inline(always)]
 fn parent_specified_instance_at(actor_ptr: *const usize, offset: usize) -> Option<*const usize> {
     unsafe {
         let info = (actor_ptr.byte_add(offset) as *const *const *const usize).read_unaligned();

--- a/src-hook/src/hooks/mod.rs
+++ b/src-hook/src/hooks/mod.rs
@@ -101,6 +101,11 @@ pub fn get_source_parent(source_type_id: u32, source: *const usize) -> Option<(u
             let parent_instance = parent_specified_instance_at(source, 0x500)?;
             Some((actor_type_id(parent_instance), actor_idx(parent_instance)))
         }
+        // Pl0600PlantRose
+        0x69C0CA71 => {
+            let parent_instance = parent_specified_instance_at(source, 0x7E0)?;
+            Some((actor_type_id(parent_instance), actor_idx(parent_instance)))
+        }
         _ => None,
     }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ tauri-build = { version = "1.5", features = [] }
 anyhow = "1.0"
 dll-syringe = "0.15.2"
 futures = "0.3"
-interprocess = { version = "1.2.1", features = ["tokio_support"] }
+interprocess = { version = "^2.0", features = ["tokio"] }
 protocol = { path = "../protocol" }
 sea-query = { version = "0"}
 sea-query-rusqlite = { version = "0", features = ["with-chrono"] }
@@ -25,6 +25,8 @@ tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-wo
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tokio = { version = "1.0", features = ["full"] }
+tokio-util = { version = "0.7.11", features = ["codec"] }
+tokio-stream = "0.1.15"
 num_enum = "0.7.2"
 chrono = "0.4"
 rusqlite = { version = "0.30.0", features = ["bundled"] }

--- a/src-tauri/lang/en/ui.json
+++ b/src-tauri/lang/en/ui.json
@@ -372,6 +372,7 @@
       }
     },
     "Pl0600": {
+      "0": "Rose Palace",
       "100": "Attack 1",
       "101": "Attack 2",
       "102": "Attack 3",


### PR DESCRIPTION
Rose Palace does a miniscule amount of damage when you place a rose, no damage number will be displayed, but the dummy will still take damage.