### PR TITLE
feat: Stun value tracking

### DIFF
--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -76,6 +76,9 @@ pub struct DamageEvent {
     pub damage: i32,
     pub flags: u64,
     pub action_id: ActionType,
+    pub attack_rate: Option<f32>,
+    pub stun_value: Option<f32>,
+    pub damage_cap: Option<i32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src-hook/src/hooks/damage.rs
+++ b/src-hook/src/hooks/damage.rs
@@ -123,6 +123,9 @@ impl OnProcessDamageHook {
             damage,
             flags,
             action_id: action_type,
+            attack_rate: Some(damage_instance.attack_rate),
+            stun_value: Some(damage_instance.stun_value),
+            damage_cap: Some(damage_instance.damage_cap),
         });
 
         let _ = self.tx.send(event);
@@ -212,6 +215,9 @@ impl OnProcessDotHook {
             damage: dmg,
             flags: 0,
             action_id: ActionType::DamageOverTime(0),
+            attack_rate: None,
+            stun_value: None,
+            damage_cap: None,
         });
 
         let _ = self.tx.send(event);

--- a/src-hook/src/hooks/damage.rs
+++ b/src-hook/src/hooks/damage.rs
@@ -1,8 +1,10 @@
+use std::ptr::NonNull;
+
 use anyhow::{anyhow, Result};
 use protocol::{ActionType, Actor, DamageEvent, Message};
 use retour::static_detour;
 
-use crate::{event, process::Process};
+use crate::{event, hooks::ffi::DamageInstance, process::Process};
 
 use super::{actor_idx, actor_type_id, get_source_parent};
 
@@ -69,13 +71,15 @@ impl OnProcessDamageHook {
         // entity->m_pSpecifiedInstance, offset 0x70 from entity pointer.
         // Returns the specific class instance of the source entity. (e.g. Instance of Pl1200 / Pl0700Ghost)
         let source_specified_instance_ptr: usize = unsafe { *(source_entity_ptr.byte_add(0x70)) };
-        let damage: i32 = unsafe { (a2.byte_add(0xD0) as *const i32).read() };
+
+        let damage_instance = unsafe { NonNull::new(a2 as *mut DamageInstance).unwrap().as_ref() };
+        let damage: i32 = damage_instance.damage;
 
         if original_value == 0 || damage <= 0 {
             return original_value;
         }
 
-        let flags: u64 = unsafe { (a2.byte_add(0xD8) as *const u64).read() };
+        let flags: u64 = damage_instance.flags;
 
         let action_type: ActionType = if ((1 << 7 | 1 << 50) & flags) != 0 {
             ActionType::LinkAttack

--- a/src-hook/src/hooks/ffi.rs
+++ b/src-hook/src/hooks/ffi.rs
@@ -2,6 +2,21 @@ use std::ffi::CString;
 
 #[derive(Debug)]
 #[repr(C)]
+pub struct DamageInstance {
+    padding_00: [u8; 0xD0],   // 0x00 - 0xD0
+    pub damage: i32,          // 0xD0
+    pub attack_rate: f32,     // 0xD4
+    pub flags: u64,           // 0xD8
+    padding_e0: [u8; 0x08],   // 0xE0
+    pub stun_value: f32,      // 0xE8
+    padding_ec: [u8; 0x68],   // 0xEC - 0x154
+    pub action_id: u32,       // 0x154
+    padding_158: [u8; 0x10C], // 0x158 - 0x264
+    pub damage_cap: u32,      // 0x264
+}
+
+#[derive(Debug)]
+#[repr(C)]
 pub struct QuestState {
     pub quest_id: u32,        // 0x00
     padding_640: [u8; 0x648], // 0x004 - 0x64C

--- a/src-hook/src/hooks/ffi.rs
+++ b/src-hook/src/hooks/ffi.rs
@@ -12,7 +12,7 @@ pub struct DamageInstance {
     padding_ec: [u8; 0x68],   // 0xEC - 0x154
     pub action_id: u32,       // 0x154
     padding_158: [u8; 0x10C], // 0x158 - 0x264
-    pub damage_cap: u32,      // 0x264
+    pub damage_cap: i32,      // 0x264
 }
 
 #[derive(Debug)]

--- a/src-tauri/lang/en/ui.json
+++ b/src-tauri/lang/en/ui.json
@@ -56,7 +56,11 @@
       "damage-percentage": "%",
       "damage-percentage-description": "Total Damage in Percentage",
       "sba": "SBA",
-      "sba-description": "Skybound Arts Gauge"
+      "sba-description": "Skybound Arts Gauge",
+      "total-stun-value": "Total Stun",
+      "total-stun-value-description": "Total Stun Value",
+      "stun-per-second": "Stun/s",
+      "stun-per-second-description": "Stun Per Second"
     },
     "stats": {
       "level": "Level",

--- a/src-tauri/src/parser/v1/mod.rs
+++ b/src-tauri/src/parser/v1/mod.rs
@@ -191,8 +191,8 @@ impl PlayerData {
     pub fn stun_modifier(&self) -> f64 {
         self.player_stats
             .as_ref()
-            .and_then(|stats| Some(stats.stun_power / 100.0))
-            .unwrap_or(1.0) as f64
+            .and_then(|stats| Some(stats.stun_power))
+            .unwrap_or(10.0) as f64
     }
 }
 
@@ -359,7 +359,7 @@ impl DerivedEncounterState {
         let stun_modifier = player_data
             .and_then(|data| data.player_stats.as_ref())
             .and_then(|stats| Some(stats.stun_power / 100.0))
-            .unwrap_or(1.0) as f64;
+            .unwrap_or(10.0) as f64;
 
         // Update stun value
         self.total_stun_value += event.stun_value.unwrap_or(0.0) as f64 * stun_modifier;

--- a/src-tauri/src/parser/v1/player_state.rs
+++ b/src-tauri/src/parser/v1/player_state.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::parser::constants::{CharacterType, FerrySkillId};
 
-use super::skill_state::SkillState;
+use super::{skill_state::SkillState, PlayerData};
 
 /// Derived stat breakdown for a player
 #[derive(Debug, Serialize, Deserialize)]
@@ -16,6 +16,8 @@ pub struct PlayerState {
     pub dps: f64,
     pub skill_breakdown: Vec<SkillState>,
     pub sba: f64,
+    pub total_stun_value: f64,
+    pub stun_per_second: f64,
 }
 
 impl PlayerState {
@@ -25,6 +27,7 @@ impl PlayerState {
 
     pub fn update_dps(&mut self, now: i64, start_time: i64) {
         self.dps = self.total_damage as f64 / ((now - start_time) as f64 / 1000.0);
+        self.stun_per_second = self.total_stun_value / ((now - start_time) as f64 / 1000.0);
     }
 
     // @todo(false): maybe Ferry specific stuff can be removed/abstracted if some extra flags are found or the attribution is fixed
@@ -65,8 +68,19 @@ impl PlayerState {
         return action;
     }
 
-    pub fn update_from_damage_event(&mut self, event: &DamageEvent) {
+    pub fn update_from_damage_event(
+        &mut self,
+        event: &DamageEvent,
+        player_data: Option<&PlayerData>,
+    ) {
         self.total_damage += event.damage as u64;
+
+        let stun_modifier = player_data
+            .and_then(|data| Some(data.stun_modifier()))
+            .unwrap_or(1.0);
+
+        let stun_value = event.stun_value.unwrap_or(0.0) as f64;
+        self.total_stun_value += stun_value * stun_modifier;
 
         let parent_character_type = CharacterType::from_hash(event.source.parent_actor_type);
 
@@ -92,13 +106,13 @@ impl PlayerState {
                 protocol::ActionType::SupplementaryDamage(_)
             ) && matches!(action, protocol::ActionType::SupplementaryDamage(_))
             {
-                skill.update_from_damage_event(event);
+                skill.update_from_damage_event(event, player_data);
                 return;
             }
 
             // If the skill is already being tracked, update it.
             if skill.action_type == action && skill.child_character_type == child_character_type {
-                skill.update_from_damage_event(event);
+                skill.update_from_damage_event(event, player_data);
                 return;
             }
         }
@@ -106,7 +120,7 @@ impl PlayerState {
         // Otherwise, create a new skill and track it.
         let mut skill = SkillState::new(action, child_character_type);
 
-        skill.update_from_damage_event(event);
+        skill.update_from_damage_event(event, player_data);
         self.skill_breakdown.push(skill);
     }
 }
@@ -125,6 +139,8 @@ mod tests {
             dps: 0.0,
             skill_breakdown: vec![],
             sba: 0.0,
+            total_stun_value: 0.0,
+            stun_per_second: 0.0,
         };
 
         player_state.update_dps(1000, 0);
@@ -142,6 +158,8 @@ mod tests {
             dps: 0.0,
             skill_breakdown: vec![],
             sba: 0.0,
+            total_stun_value: 0.0,
+            stun_per_second: 0.0,
         };
 
         let damage_event = DamageEvent {
@@ -160,9 +178,12 @@ mod tests {
             action_id: ActionType::Normal(1),
             damage: 100,
             flags: 0,
+            attack_rate: None,
+            stun_value: None,
+            damage_cap: None,
         };
 
-        player_state.update_from_damage_event(&damage_event);
+        player_state.update_from_damage_event(&damage_event, None);
 
         assert_eq!(player_state.total_damage, 100);
         assert_eq!(player_state.skill_breakdown.len(), 1);
@@ -179,6 +200,8 @@ mod tests {
             dps: 0.0,
             skill_breakdown: vec![],
             sba: 0.0,
+            total_stun_value: 0.0,
+            stun_per_second: 0.0,
         };
 
         let damage_event = DamageEvent {
@@ -197,11 +220,14 @@ mod tests {
             action_id: ActionType::Normal(1),
             damage: 100,
             flags: 0,
+            attack_rate: None,
+            stun_value: None,
+            damage_cap: None,
         };
 
-        player_state.update_from_damage_event(&damage_event);
-        player_state.update_from_damage_event(&damage_event);
-        player_state.update_from_damage_event(&damage_event);
+        player_state.update_from_damage_event(&damage_event, None);
+        player_state.update_from_damage_event(&damage_event, None);
+        player_state.update_from_damage_event(&damage_event, None);
 
         assert_eq!(player_state.total_damage, 300);
         assert_eq!(player_state.skill_breakdown.len(), 1);
@@ -218,6 +244,8 @@ mod tests {
             dps: 0.0,
             skill_breakdown: vec![],
             sba: 0.0,
+            stun_per_second: 0.0,
+            total_stun_value: 0.0,
         };
 
         let skill_one = DamageEvent {
@@ -236,6 +264,9 @@ mod tests {
             action_id: ActionType::Normal(1),
             damage: 100,
             flags: 0,
+            attack_rate: None,
+            stun_value: None,
+            damage_cap: None,
         };
 
         let skill_two = DamageEvent {
@@ -254,11 +285,14 @@ mod tests {
             action_id: ActionType::Normal(2),
             damage: 100,
             flags: 0,
+            attack_rate: None,
+            stun_value: None,
+            damage_cap: None,
         };
 
-        player_state.update_from_damage_event(&skill_one);
-        player_state.update_from_damage_event(&skill_two);
-        player_state.update_from_damage_event(&skill_two);
+        player_state.update_from_damage_event(&skill_one, None);
+        player_state.update_from_damage_event(&skill_two, None);
+        player_state.update_from_damage_event(&skill_two, None);
 
         assert_eq!(player_state.total_damage, 300);
         assert_eq!(player_state.skill_breakdown.len(), 2);
@@ -275,6 +309,8 @@ mod tests {
             dps: 0.0,
             skill_breakdown: vec![],
             sba: 0.0,
+            stun_per_second: 0.0,
+            total_stun_value: 0.0,
         };
 
         let parent_skill = DamageEvent {
@@ -293,6 +329,9 @@ mod tests {
             action_id: ActionType::Normal(1),
             damage: 100,
             flags: 0,
+            attack_rate: None,
+            stun_value: None,
+            damage_cap: None,
         };
 
         let child_skill = DamageEvent {
@@ -311,11 +350,14 @@ mod tests {
             action_id: ActionType::Normal(1),
             damage: 100,
             flags: 0,
+            attack_rate: None,
+            stun_value: None,
+            damage_cap: None,
         };
 
-        player_state.update_from_damage_event(&parent_skill);
-        player_state.update_from_damage_event(&child_skill);
-        player_state.update_from_damage_event(&child_skill);
+        player_state.update_from_damage_event(&parent_skill, None);
+        player_state.update_from_damage_event(&child_skill, None);
+        player_state.update_from_damage_event(&child_skill, None);
 
         assert_eq!(player_state.total_damage, 200);
         assert_eq!(player_state.skill_breakdown.len(), 2);

--- a/src-tauri/src/parser/v1/player_state.rs
+++ b/src-tauri/src/parser/v1/player_state.rs
@@ -77,7 +77,7 @@ impl PlayerState {
 
         let stun_modifier = player_data
             .and_then(|data| Some(data.stun_modifier()))
-            .unwrap_or(1.0);
+            .unwrap_or(10.0);
 
         let stun_value = event.stun_value.unwrap_or(0.0) as f64;
         self.total_stun_value += stun_value * stun_modifier;

--- a/src-tauri/src/parser/v1/skill_state.rs
+++ b/src-tauri/src/parser/v1/skill_state.rs
@@ -51,7 +51,7 @@ impl SkillState {
 
         let stun_modifier = player_data
             .and_then(|data| Some(data.stun_modifier()))
-            .unwrap_or(1.0);
+            .unwrap_or(10.0);
 
         let stun_value = event.stun_value.unwrap_or(0.0) as f64;
 

--- a/src-tauri/src/parser/v1/skill_state.rs
+++ b/src-tauri/src/parser/v1/skill_state.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::parser::constants::CharacterType;
 
+use super::PlayerData;
+
 /// Derived stat breakdown of a particular skill
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -19,6 +21,10 @@ pub struct SkillState {
     pub max_damage: Option<u64>,
     /// Total damage done by this skill
     pub total_damage: u64,
+    /// Maximum stun value done by this skill
+    pub max_stun_value: f64,
+    /// Total stun value done by this skill
+    pub total_stun_value: f64,
 }
 
 impl SkillState {
@@ -30,12 +36,27 @@ impl SkillState {
             min_damage: None,
             max_damage: None,
             total_damage: 0,
+            max_stun_value: 0.0,
+            total_stun_value: 0.0,
         }
     }
 
-    pub fn update_from_damage_event(&mut self, event: &DamageEvent) {
+    pub fn update_from_damage_event(
+        &mut self,
+        event: &DamageEvent,
+        player_data: Option<&PlayerData>,
+    ) {
         self.hits += 1;
         self.total_damage += event.damage as u64;
+
+        let stun_modifier = player_data
+            .and_then(|data| Some(data.stun_modifier()))
+            .unwrap_or(1.0);
+
+        let stun_value = event.stun_value.unwrap_or(0.0) as f64;
+
+        self.max_stun_value = self.max_stun_value.max(stun_value * stun_modifier);
+        self.total_stun_value += stun_value * stun_modifier;
 
         if let Some(min_damage) = self.min_damage {
             self.min_damage = Some(min_damage.min(event.damage as u64));
@@ -77,6 +98,9 @@ mod tests {
             action_id: ActionType::Normal(1),
             damage: 100,
             flags: 0,
+            attack_rate: None,
+            stun_value: None,
+            damage_cap: None,
         };
 
         let damage_event_two = DamageEvent {
@@ -95,10 +119,13 @@ mod tests {
             action_id: ActionType::Normal(1),
             damage: 1999,
             flags: 0,
+            attack_rate: None,
+            stun_value: None,
+            damage_cap: None,
         };
 
-        skill_state.update_from_damage_event(&damage_event);
-        skill_state.update_from_damage_event(&damage_event_two);
+        skill_state.update_from_damage_event(&damage_event, None);
+        skill_state.update_from_damage_event(&damage_event_two, None);
 
         assert_eq!(skill_state.hits, 2);
         assert_eq!(skill_state.min_damage, Some(100));

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -61,7 +61,15 @@ export const Table = ({
   };
 
   // If the meter is in live mode, only show the overlay columns that are enabled, otherwise show all columns.
-  const columns = live ? overlay_columns : [MeterColumns.TotalDamage, MeterColumns.DPS, MeterColumns.DamagePercentage];
+  const columns = live
+    ? overlay_columns
+    : [
+        MeterColumns.TotalDamage,
+        MeterColumns.DPS,
+        MeterColumns.TotalStunValue,
+        MeterColumns.StunPerSecond,
+        MeterColumns.DamagePercentage,
+      ];
 
   return (
     <table className={`player-table table w-full ${show_full_values ? "full-values" : ""}`}>

--- a/src/components/usePlayerRow.ts
+++ b/src/components/usePlayerRow.ts
@@ -32,6 +32,7 @@ export const usePlayerRow = (live: boolean, player: ComputedPlayerState, partyDa
 
   const [totalDamage, totalDamageUnit] = humanizeNumbers(player.totalDamage);
   const [dps, dpsUnit] = humanizeNumbers(player.dps);
+  const [totalStunValue, totalStunValueUnit] = humanizeNumbers(player.totalStunValue);
 
   // Function for matching the column type to the value to display in the table.
   const matchColumnTypeToValue = (showFullValues: boolean, column: MeterColumns): ColumnValue => {
@@ -48,13 +49,27 @@ export const usePlayerRow = (live: boolean, player: ComputedPlayerState, partyDa
         return showFullValues
           ? { value: (player.sba / 10).toFixed(2) }
           : { value: (player.sba / 10).toFixed(2), unit: "%" };
+      case MeterColumns.StunPerSecond:
+        return { value: (player.stunPerSecond || 0).toLocaleString() };
+      case MeterColumns.TotalStunValue:
+        return showFullValues
+          ? { value: (player.totalStunValue || 0).toLocaleString() }
+          : { value: totalStunValue, unit: totalStunValueUnit };
       default:
         return { value: "" };
     }
   };
 
   // If the meter is in live mode, only show the overlay columns that are enabled, otherwise show all columns.
-  const columns = live ? overlay_columns : [MeterColumns.TotalDamage, MeterColumns.DPS, MeterColumns.DamagePercentage];
+  const columns = live
+    ? overlay_columns
+    : [
+        MeterColumns.TotalDamage,
+        MeterColumns.DPS,
+        MeterColumns.TotalStunValue,
+        MeterColumns.StunPerSecond,
+        MeterColumns.DamagePercentage,
+      ];
 
   return {
     columns,

--- a/src/components/useSkillBreakdown.ts
+++ b/src/components/useSkillBreakdown.ts
@@ -71,6 +71,8 @@ export const useSkillBreakdown = (player: ComputedPlayerState) => {
                 maxDamage: skill.maxDamage,
                 percentage: skill.percentage,
                 skills: [skill],
+                maxStunValue: skill.maxStunValue,
+                totalStunValue: skill.totalStunValue,
               });
             }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,10 @@ export type SkillState = {
   maxDamage: number | null;
   /** Total damage of the skill */
   totalDamage: number;
+  /** Total stun value of the skill hits */
+  totalStunValue: number;
+  /** Maximum recorded stun value of the skill */
+  maxStunValue: number;
 };
 
 export type ComputedSkillState = SkillState & {
@@ -72,6 +76,10 @@ export type ComputedSkillGroup = {
   percentage: number;
   /** Skills */
   skills?: ComputedSkillState[];
+  /** Total stun value of the skill hits */
+  totalStunValue: number;
+  /** Maximum recorded stun value of the skill */
+  maxStunValue: number;
 };
 
 export type PlayerState = {
@@ -85,6 +93,10 @@ export type PlayerState = {
   dps: number;
   /** Amount of SBA Gauge (0.0 - 1000.0) */
   sba: number;
+  /** Total stun value */
+  totalStunValue: number;
+  /** Stun per second over the encounter time */
+  stunPerSecond: number;
   /** Time of the last damage dealt */
   lastDamageTime: number;
   /** Stats for individual skills logged */
@@ -207,6 +219,8 @@ export enum MeterColumns {
   TotalDamage = "damage",
   DamagePercentage = "damage-percentage",
   SBA = "sba",
+  TotalStunValue = "total-stun-value",
+  StunPerSecond = "stun-per-second",
 }
 
 export type SortType = MeterColumns;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,6 +170,10 @@ export const sortPlayers = (players: ComputedPlayerState[], sortType: SortType, 
       return sortDirection === "asc" ? a?.percentage - b?.percentage : b?.percentage - a?.percentage;
     } else if (sortType === MeterColumns.SBA) {
       return sortDirection === "asc" ? a?.sba - b?.sba : b?.sba - a?.sba;
+    } else if (sortType === MeterColumns.TotalStunValue) {
+      return sortDirection === "asc" ? a?.totalStunValue - b?.totalStunValue : b?.totalStunValue - a?.totalStunValue;
+    } else if (sortType === MeterColumns.StunPerSecond) {
+      return sortDirection === "asc" ? a?.stunPerSecond - b?.stunPerSecond : b?.stunPerSecond - a?.stunPerSecond;
     }
 
     return 0;


### PR DESCRIPTION
Initial support for stun value tracking. #55 

- Refactor to `DamageInstance` FFI struct for working with the raw ptr easier.
- Add field for stun amount, attack rate and damage cap.

Stun value is on damage instance regardless of it was applied or not. Stun value seems to be the base stun value input before equipment / masteries are calculated.