### PR TITLE
Fix: Stun being off by 100x in 1.8.0.alpha.3

### DIFF
--- a/src-tauri/src/parser/v1/mod.rs
+++ b/src-tauri/src/parser/v1/mod.rs
@@ -31,7 +31,7 @@ impl<'a> AdjustedDamageInstance<'a> {
         let stun_modifier = player_data
             .as_ref()
             .and_then(|data| data.player_stats.as_ref())
-            .map(|stats| stats.stun_power / 100.0)
+            .map(|stats| stats.stun_power)
             .unwrap_or(10.0) as f64;
 
         let stun_damage = event.stun_value.unwrap_or(0.0) as f64 * stun_modifier;

--- a/src-tauri/src/parser/v1/mod.rs
+++ b/src-tauri/src/parser/v1/mod.rs
@@ -29,10 +29,8 @@ pub struct AdjustedDamageInstance<'a> {
 impl<'a> AdjustedDamageInstance<'a> {
     pub fn from_damage_event(event: &'a DamageEvent, player_data: Option<&'a PlayerData>) -> Self {
         let stun_modifier = player_data
-            .as_ref()
-            .and_then(|data| data.player_stats.as_ref())
-            .map(|stats| stats.stun_power)
-            .unwrap_or(10.0) as f64;
+            .map(|data| data.stun_modifier())
+            .unwrap_or(100.0) as f64;
 
         let stun_damage = event.stun_value.unwrap_or(0.0) as f64 * stun_modifier;
 
@@ -216,7 +214,7 @@ impl PlayerData {
         self.player_stats
             .as_ref()
             .map(|stats| stats.stun_power)
-            .unwrap_or(10.0) as f64
+            .unwrap_or(100.0) as f64
     }
 }
 


### PR DESCRIPTION
Fixes a bug in commit db20154 where [stun is divided by 100 for some reason](https://github.com/false-spring/gbfr-logs/commit/db201540939388ebb7650a56fc8008bcf051dca5#diff-c07797f743ab95b8111eeeb1b0647d61dc30085fc4fadc5a93304be4efafc127R34) which results in the displayed number being too low after 1.8.0.alpha.3 prerelease

**Before:** 
![image](https://github.com/false-spring/gbfr-logs/assets/34401983/8d4e9e2c-1ef5-4dce-9379-54424bed9eda)

**After:**
![image](https://github.com/false-spring/gbfr-logs/assets/34401983/4a8f4866-ffec-4c83-ad47-69db1a25fc1f)