### PR TITLE
fix: Use applied stun value for tracking

### DIFF
--- a/src-tauri/src/parser/v1/mod.rs
+++ b/src-tauri/src/parser/v1/mod.rs
@@ -28,11 +28,7 @@ pub struct AdjustedDamageInstance<'a> {
 
 impl<'a> AdjustedDamageInstance<'a> {
     pub fn from_damage_event(event: &'a DamageEvent, player_data: Option<&'a PlayerData>) -> Self {
-        let stun_modifier = player_data
-            .map(|data| data.stun_modifier())
-            .unwrap_or(100.0) as f64;
-
-        let stun_damage = event.stun_value.unwrap_or(0.0) as f64 * stun_modifier;
+        let stun_damage = event.stun_value.unwrap_or(0.0) as f64;
 
         Self {
             event,
@@ -207,15 +203,6 @@ pub struct PlayerData {
     overmastery_info: Option<OvermasteryInfo>,
     /// Player stats for this player
     player_stats: Option<PlayerStats>,
-}
-
-impl PlayerData {
-    pub fn stun_modifier(&self) -> f64 {
-        self.player_stats
-            .as_ref()
-            .map(|stats| stats.stun_power)
-            .unwrap_or(100.0) as f64
-    }
 }
 
 /// Derived breakdown for an enemy target

--- a/src-tauri/src/parser/v1/player_state.rs
+++ b/src-tauri/src/parser/v1/player_state.rs
@@ -443,8 +443,7 @@ mod tests {
             Some(&player_data),
         ));
 
-        // actual_stun_value = stun_value * stun_power
-        assert_eq!(player_state.total_stun_value, 5.0 * 130.0);
+        assert_eq!(player_state.total_stun_value, 5.0);
     }
 
     #[test]
@@ -487,7 +486,6 @@ mod tests {
             None,
         ));
 
-        // actual_stun_value = stun_value * stun_power
-        assert_eq!(player_state.total_stun_value, 5.0 * 100.0);
+        assert_eq!(player_state.total_stun_value, 5.0);
     }
 }


### PR DESCRIPTION
Instead of calculating stun by taking the _would-be stun damage * stun modifier from the player data_, this will track the actual amount that was applied to the enemy. **This does have a side-effect of only tracking "applicable" stun, so stun will not be tracked if it is not applied (cooldown, lockout)**

This also removes the requirement of requiring player data to be available for calculating the stun modifier, since now we just use the final stun value result from what was applied.

I've noticed with Rosetta's plants do apply stun, but since their attack speed is too slow, their applied stun dissipates quickly on Sir Barrold.

Fixes #157.